### PR TITLE
Event Processor for Segment Backend

### DIFF
--- a/eventtracking/processors/segment.py
+++ b/eventtracking/processors/segment.py
@@ -8,7 +8,27 @@ class SegmentTopLevelPropertiesProcessor(object):
     of the event. Copy all properties contained within the event's 'data' key
     to the top level of the event dict.
 
-    We duplicate instead of reassign to not break previous integrations.
+    We copy properties instead of reassign to not break previous integrations.
+
+    For example: by default, tracker.emit() will produce an event
+    with most interesting properties in the `data` key, like:
+
+    analytics.track('13', 'edx.bi.user.chapter.started', {
+    'context': { ... },
+    'data': {
+        'block_id': 'block-v1:foo+101+forever+type@chapter+block@3707382f0c284b6aadbd7c50d767ca8f',
+        'block_name': 'Section 1',
+        'completion_percent': 33.3333333333333,
+        'course_id': 'course-v1:foo+101+forever',
+        'course_name': 'CompletionTest',
+        'label': 'chapter Section 1 started'
+    },
+    'name': 'edx.bi.user.chapter.started',
+    ...
+    })
+
+    Many/most Segment Destinations will not be able to access properties inside 'data'.
+    Copy these to the top level of the event before emitting.
 
     Always returns the event for continued processing.
     """
@@ -20,6 +40,6 @@ class SegmentTopLevelPropertiesProcessor(object):
                     event[key].update(event['data'][key])
                 except (KeyError, AttributeError):
                     event[key] = val
-        except KeyError:  # no data
+        except KeyError:  # no 'data'
             pass
         return event

--- a/eventtracking/processors/segment.py
+++ b/eventtracking/processors/segment.py
@@ -1,9 +1,5 @@
 """Process events to be more useful with Segment backend"""
 
-from __future__ import absolute_import
-
-from eventtracking.processors.exceptions import EventEmissionExit
-
 
 class SegmentTopLevelPropertiesProcessor(object):
     """

--- a/eventtracking/processors/segment.py
+++ b/eventtracking/processors/segment.py
@@ -1,6 +1,7 @@
 """Process events to be more useful with Segment backend"""
 
 from __future__ import absolute_import
+
 from eventtracking.processors.exceptions import EventEmissionExit
 
 
@@ -13,7 +14,7 @@ class SegmentTopLevelPropertiesProcessor(object):
 
     We duplicate instead of reassign to not break previous integrations.
 
-    Returns the event
+    Always returns the event for continued processing.
     """
 
     def __call__(self, event):

--- a/eventtracking/processors/segment.py
+++ b/eventtracking/processors/segment.py
@@ -36,9 +36,15 @@ class SegmentTopLevelPropertiesProcessor(object):
     def __call__(self, event):
         try:
             for key, val in event['data'].items():
-                try:
-                    event[key].update(event['data'][key])
-                except (KeyError, AttributeError):
+                if key in event:
+                    try:
+                        event[key].update(event['data'][key])  # dict
+                    except AttributeError:
+                        try:
+                            event[key].extend(event['data'][key])  # list
+                        except AttributeError:
+                            event[key] = val
+                else:
                     event[key] = val
         except KeyError:  # no 'data'
             pass

--- a/eventtracking/processors/segment.py
+++ b/eventtracking/processors/segment.py
@@ -1,0 +1,28 @@
+"""Process events to be more useful with Segment backend"""
+
+from __future__ import absolute_import
+from eventtracking.processors.exceptions import EventEmissionExit
+
+
+class SegmentTopLevelPropertiesProcessor(object):
+    """
+
+    Most Segment.io Destination APIs require properties to be at the top level
+    of the event. Copy all properties contained within the event's 'data' key
+    to the top level of the event dict.
+
+    We duplicate instead of reassign to not break previous integrations.
+
+    Returns the event
+    """
+
+    def __call__(self, event):
+        try:
+            for key, val in event['data'].items():
+                try:
+                    event[key].update(event['data'][key])
+                except (KeyError, AttributeError):
+                    event[key] = val
+        except KeyError:  # no data
+            pass
+        return event


### PR DESCRIPTION
Segment Destinations need properties at top level of event. Event-tracking puts them in a `data` object which doesn't work well.  Process event and return it for further processing.
For Appsembler's current purposes we're going to want to cherry-pick this back to the version we use for the Hawthorn release.

We can't accomplish the Marketo integration for Chef without this.  It may be that we want to implement this in our edx-platform, or in an IDA, but it should be useful for upstream. 

Looking for some initial reactions.